### PR TITLE
Improve banner image upload handling

### DIFF
--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -17,6 +17,7 @@ export async function POST(request: NextRequest) {
 
     const data = await request.formData();
     const file: File | null = data.get('image') as unknown as File;
+    const folder = (data.get('folder') as string) || 'blog';
 
     if (!file) {
       return NextResponse.json(
@@ -47,8 +48,8 @@ export async function POST(request: NextRequest) {
     // Generar nombre único para el archivo
     const timestamp = Date.now();
     const originalName = file.name.replace(/\s+/g, '-').toLowerCase();
-    const fileName = `blog-${timestamp}-${originalName}`;
-    
+    const prefix = folder === 'banners' ? 'banner' : 'blog';
+    const fileName = `${prefix}-${timestamp}-${originalName}`;
     // Crear directorio si no existe
     const uploadDir = path.join(process.cwd(), 'public/images/blog');
     try {
@@ -69,6 +70,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       success: true,
       imageUrl,
+      filePath,
       message: 'Imagen subida exitosamente'
     });
 

--- a/src/components/admin/BlogForm.tsx
+++ b/src/components/admin/BlogForm.tsx
@@ -60,6 +60,7 @@ const BlogForm: React.FC<BlogFormProps> = ({ post, isEdit = false }) => {
       // Opción 1: Usar la API de upload (si está implementada)
       const formData = new FormData();
       formData.append('image', file);
+      formData.append('folder', 'blog');
 
       const uploadResponse = await fetch('/api/upload', {
         method: 'POST',
@@ -75,39 +76,16 @@ const BlogForm: React.FC<BlogFormProps> = ({ post, isEdit = false }) => {
           image: uploadData.imageUrl
         }));
       } else {
-        // Si la API de upload no funciona, usar método alternativo
-        await handleImageUploadFallback(file);
+        const data = await uploadResponse.json();
+        setError(data.error || 'Error al subir la imagen. Intenta de nuevo.');
       }
 
     } catch (error) {
-      console.log('Upload API no disponible, usando método alternativo');
-      await handleImageUploadFallback(file);
+      console.error('Error uploading image:', error);
+      setError('Error al subir la imagen. Intenta de nuevo.');
     } finally {
       setUploadingImage(false);
     }
-  };
-
-  const handleImageUploadFallback = async (file: File) => {
-    // Crear preview inmediato con FileReader
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const result = e.target?.result as string;
-      setImagePreview(result);
-      
-      // Generar una URL ficticia para el formulario
-      // En un proyecto real, aquí tendrías la URL del servidor
-      const fileName = `blog-${Date.now()}-${file.name.replace(/\s+/g, '-').toLowerCase()}`;
-      const imageUrl = `/images/blog/${fileName}`;
-      
-      setFormData(prev => ({
-        ...prev,
-        image: imageUrl
-      }));
-      
-      console.log('Imagen preparada (ficticia):', imageUrl);
-      console.log('En un proyecto real, la imagen se subiría al servidor');
-    };
-    reader.readAsDataURL(file);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary
- return the uploaded file path from `/api/upload`
- add folder param for banner/blog uploads
- report upload errors in blog and banner forms
- disable banner creation when no image is uploaded

## Testing
- `npm run lint` *(fails: React/TS lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_684735786984832c9d6e52c2b4a64f75