### PR TITLE
Add order validation for banners

### DIFF
--- a/src/app/api/banners/[id]/route.ts
+++ b/src/app/api/banners/[id]/route.ts
@@ -1,14 +1,15 @@
 // src/app/api/banners/[id]/route.ts - API individual de banners
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyToken } from '@/lib/auth';
-import { 
-  getBannerById, 
-  updateBanner, 
+import {
+  getBannerById,
+  updateBanner,
   deleteBanner,
   toggleActive,
   moveBannerUp,
   moveBannerDown,
-  duplicateBanner
+  duplicateBanner,
+  BannerOrderError
 } from '@/lib/banners';
 
 // Definir el tipo correcto para los parámetros
@@ -135,7 +136,7 @@ export async function PUT(
     if (active !== undefined) updateData.active = active;
     
     const updatedBanner = await updateBanner(bannerId, updateData);
-    
+
     if (!updatedBanner) {
       return NextResponse.json(
         { error: 'Error al actualizar el banner' },
@@ -153,6 +154,12 @@ export async function PUT(
     
     return NextResponse.json({ banner: updatedBanner });
   } catch (error) {
+    if (error instanceof BannerOrderError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status }
+      );
+    }
     console.error('❌ API Banners - Error updating banner:', error);
     return NextResponse.json(
       { error: 'Error interno del servidor' },

--- a/src/app/api/banners/route.ts
+++ b/src/app/api/banners/route.ts
@@ -1,11 +1,12 @@
 // src/app/api/banners/route.ts - API principal de banners
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyToken } from '@/lib/auth';
-import { 
-  getAllBanners, 
+import {
+  getAllBanners,
   getActiveBanners,
   createBanner,
-  getBannerStats
+  getBannerStats,
+  BannerOrderError
 } from '@/lib/banners';
 
 // GET - obtener banners
@@ -128,6 +129,12 @@ export async function POST(request: NextRequest) {
     
     return NextResponse.json({ banner: newBanner }, { status: 201 });
   } catch (error) {
+    if (error instanceof BannerOrderError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status }
+      );
+    }
     console.error('❌ API Banners - Error creando banner:', error);
     return NextResponse.json(
       { error: 'Error interno del servidor' },


### PR DESCRIPTION
## Summary
- enforce unique positive `order` when creating or updating banners
- expose `BannerOrderError` and surface 400 responses via the API

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68473ba19cc0832cb68e9f8ba8ad6fc4