### PR TITLE
Use dynamic folder path in upload API

### DIFF
--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -50,20 +50,16 @@ export async function POST(request: NextRequest) {
     const originalName = file.name.replace(/\s+/g, '-').toLowerCase();
     const prefix = folder === 'banners' ? 'banner' : 'blog';
     const fileName = `${prefix}-${timestamp}-${originalName}`;
-    // Crear directorio si no existe
-    const uploadDir = path.join(process.cwd(), 'public/images/blog');
-    try {
-      await mkdir(uploadDir, { recursive: true });
-    } catch (error) {
-      // El directorio ya existe, continuar
-    }
+    // Crear directorio de destino basado en la carpeta enviada
+    const uploadDir = path.join(process.cwd(), 'public/images', folder);
+    await mkdir(uploadDir, { recursive: true });
 
     // Guardar archivo
     const filePath = path.join(uploadDir, fileName);
     await writeFile(filePath, buffer);
 
     // Retornar URL de la imagen
-    const imageUrl = `/images/blog/${fileName}`;
+    const imageUrl = `/images/${folder}/${fileName}`;
 
     console.log('✅ Imagen guardada exitosamente:', imageUrl);
 


### PR DESCRIPTION
## Summary
- fix upload directory path to use the provided folder
- build returned image URL dynamically
- ensure directory exists with `mkdir(..., { recursive: true })`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684743078814832cb79183e451f9fcc1