### PR TITLE
Restrict allowed image hosts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,11 +9,19 @@ const nextConfig = {
   },
   // Configuración mejorada para imágenes
   images: {
-    // Permitir dominios externos si es necesario
+    // Dominios externos permitidos para cargar imágenes
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: '**', // Permitir cualquier dominio HTTPS
+        hostname: 'res.cloudinary.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'bodytherapyllc.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'www.bodytherapyllc.com',
       },
       {
         protocol: 'http',


### PR DESCRIPTION
## Summary
- tighten `images.remotePatterns` to the production Cloudinary and site domains

## Testing
- `npm run lint`
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npm run build` *(fails: Failed to fetch the engine file at https://binaries.prisma.sh/... 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_684c841e43d0832cb96929bd8798b55f