### PR TITLE
Fix Cloudinary upload options

### DIFF
--- a/scripts/migrate-to-cloudinary.ts
+++ b/scripts/migrate-to-cloudinary.ts
@@ -211,8 +211,7 @@ class ImageMigrator {
         folder: cloudinaryFolder,
         public_id,
         tags: [type, 'migrated', process.env.NODE_ENV || 'production'],
-        quality: 'auto',
-        format: 'auto'
+        quality: 'auto'
       });
 
       console.log(`📤 Imagen subida exitosamente: ${result.secure_url}`);

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -78,8 +78,7 @@ export async function POST(request: NextRequest) {
       folder: cloudinaryFolder,
       public_id,
       tags: [folder, 'body-therapy', process.env.NODE_ENV || 'development'],
-      quality: 'auto',
-      format: 'auto' // Optimización automática de formato
+      quality: 'auto'
     });
 
     console.log('✅ Upload: Imagen subida exitosamente a Cloudinary');


### PR DESCRIPTION
## Summary
- remove `format: 'auto'` from Cloudinary upload options
- same change in migration script

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c88c813d0832c9f03e73b133f1a7a